### PR TITLE
Allow cjs config file extension to support type: module in package.json

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -87,7 +87,7 @@ export const getConfig = async (options: Options) => {
           ].join(' ')
         )
       }
-    } else if (ext === '.js') {
+    } else if (ext === '.js' || ext === '.cjs') {
       // js
       try {
         const { default: configJs } = await import(resolve(cwd(), configFile))


### PR DESCRIPTION
Simple fix to allow `.cjs` extension in `"type": "module"` projects.
```json
"web-image-gen": "web-image-gen generate --verbose --config ./.web-image-gen.cjs"
```

Fixes #6 