### PR TITLE
Include original image width and height in generated content

### DIFF
--- a/packages/cli/src/generate.ts
+++ b/packages/cli/src/generate.ts
@@ -49,6 +49,10 @@ export default async (config: Config, options: Options) => {
       const metaPath = imagePath.replace(imageOutputRegExp, '.json')
       const genDirPath = resolve(imageDirPath, config.images.slug)
       const sharpFile = sharp(imagePath)
+      const metadata = await sharpFile.metadata()
+
+      console.log(sharpFile)
+
       const sharpPromises = []
       let metaExists = true
       manifest[imageSlug] = {
@@ -57,6 +61,8 @@ export default async (config: Config, options: Options) => {
         meta: null,
         placeholder: '',
         sizes: {},
+        width: metadata.width || 0,
+        height: metadata.height || 0,
       }
 
       // load metadata if exists

--- a/packages/common/types/ImageSet.d.ts
+++ b/packages/common/types/ImageSet.d.ts
@@ -8,6 +8,8 @@ export type ImageSet = {
   sizes: {
     [key: string]: Record<string, string>
   }
+  width: number
+  height: number
 }
 
 export type ImageSets = Record<string, ImageSet>


### PR DESCRIPTION
Include original image `width` and `height` in generated content, to avoud layout shift when image is loaded.

Fixes #8 